### PR TITLE
Fixing single_cls function in twoD_dataset.py

### DIFF
--- a/skultrafast/twoD_dataset.py
+++ b/skultrafast/twoD_dataset.py
@@ -179,6 +179,8 @@ class TwoDim:
     "Array with the data, shape must be (t.size, wn_probe.size, wn_pump.size)"
     info: Dict = {}
     "Meta Info"
+    single_cls_result_: Optional[SingleCLSResult] = None
+    "Contains the data from a Single CLS analysis"
     cls_result_: Optional[CLSResult] = None
     "Contains the data from a CLS analysis"
     plot: 'TwoDimPlotter' = attr.Factory(TwoDimPlotter, True)  # typing: Ignore
@@ -413,8 +415,18 @@ class TwoDim:
             r = WLS(y, add_constant(x), weights=1 / yerr**2).fit()
         else:
             r = OLS(y, add_constant(x)).fit()
-        return SingleCLSResult(x + pu[pu_idx].mean(), y, yerr, r.params[0], r, x,
-                               r.predict())
+        
+        ret = SingleCLSResult(pump_wn=x + pu[pu_idx].mean(),
+                        max_pos=y,
+                        max_pos_err=yerr,
+                        slope=r.params[0],
+                        reg_result=r,
+                        recentered_pump_wn=x,
+                        linear_fit=r.predict())
+        
+        self.single_cls_result_ = ret
+
+        return ret
 
     def cls(self, **cls_args) -> CLSResult:
         """Calculates the CLS for all 2d-spectra. The arguments are given

--- a/skultrafast/twoD_dataset.py
+++ b/skultrafast/twoD_dataset.py
@@ -345,8 +345,14 @@ class TwoDim:
 
         Returns
         -------
-        (x, y, r)
-            Return x, y and the regression result r
+        Returns SingleCLSResult object with attributes:
+                        pump_wn
+                        max_pos
+                        max_pos_err
+                        slope
+                        reg_result
+                        recentered_pump_wn
+                        linear_fit
         """
         pu = self.pump_wn
         pr = self.probe_wn


### PR DESCRIPTION
Current implementation of single_cls function returns a tuple with CLS data inside, but example code and other similar functions depend on returning a class object with methods to call data, such as SingleCLSResult.max_pos.

This edit modifies the single_cls function to behave like the cls function in the same file, where it returns a class object. This fixes the example code and is more intuitive to users who may not know what the data structure of the resulting tuple is, allowing them to just call the necessary class method instead.

If the direct return of a tuple dataset was intended, ignore this pull request and I can submit a change to the example code to work with the tuple data instead.